### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rajpatel8/WicketWise/security/code-scanning/1](https://github.com/rajpatel8/WicketWise/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `contents: read` permission is sufficient for most steps, such as checking out the repository and caching Gradle packages.
- The `actions: read` permission is required for downloading artifacts from other workflows.
- The `contents: write` permission is not needed since the workflow does not modify repository contents.

The `permissions` block can be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
